### PR TITLE
Changing how to get the order in ipn method

### DIFF
--- a/includes/class-wc-pagarme-api.php
+++ b/includes/class-wc-pagarme-api.php
@@ -765,7 +765,7 @@ class WC_Pagarme_API {
 		global $wpdb;
 
 		$posted   = wp_unslash( $posted );
-		$order_id = absint( $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_wc_pagarme_transaction_id' AND meta_value = %d", $posted['id'] ) ) );
+		$order_id = absint( $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM $wpdb->postmeta WHERE meta_key = '_transaction_id' AND meta_value = %d AND post_id in (SELECT post_id from $wpdb->postmeta WHERE meta_key = '_payment_method' AND meta_value IN ('pagarme-credit-card', 'pagarme-banking-ticket'))", $posted['id'] ) ) );
 		$order    = wc_get_order( $order_id );
 		$status   = sanitize_text_field( $posted['current_status'] );
 


### PR DESCRIPTION
## Problema
Fazendo os seguintes passos:
1. Cliente compra
2. Paga (checkout transp.)
3. Pagar.me reprova
4. Cliente vai no woocommerce em meus pedidos, abre o pedido reprovado e tenta pagar novamente
5. Pagar.Me aprova
6. WooCommerce fica com pedido aguardando
7. Pagar.me fica com pedido pago

## Solução
Ao pagar via menu 'meus pedidos', a linha (tabela wp_postmeta) wp_pagarme_transaction_id não é atualizada com o id da nova transação, mas _transaction_id é. Mudando, então, a maneira de como `process_successful_ipn` procura o pedido seria um jeito de resolver o caso