### PR TITLE
add pending_review status

### DIFF
--- a/includes/class-wc-pagarme-api.php
+++ b/includes/class-wc-pagarme-api.php
@@ -803,6 +803,14 @@ class WC_Pagarme_API {
 				}
 
 				break;
+			case 'pending_review':
+				$transaction_id  = get_post_meta( $order->id, '_wc_pagarme_transaction_id', true );
+				$transaction_url = '<a href="https://dashboard.pagar.me/#/transactions/' . intval( $transaction_id ) . '">https://dashboard.pagar.me/#/transactions/' . intval( $transaction_id ) . '</a>';
+
+				/* translators: %s transaction details url */
+				$order->update_status( 'on-hold', __( 'Pagar.me: You should manually analyze this transaction to continue payment flow, access %s to do it!', 'woocommerce-pagarme'  ), $transaction_url  );
+
+				break;
 			case 'processing' :
 				$order->update_status( 'on-hold', __( 'Pagar.me: The transaction is being processed.', 'woocommerce-pagarme' ) );
 


### PR DESCRIPTION
Adiciona ao plugin suporte ao novo status do Pagar.me, o `pending_review`. Por acreditar que ele possa compartilhar o mesmo status de `processing`, abri o PR dessa maneira, mas posso fazer outra abordagem para criar um novo status no woocommerce, o que acha @claudiosanches ?