### PR TITLE
Ajustado código de retorno do IPN para que em caso de falha o Pagar.me tente novamente

### DIFF
--- a/includes/class-wc-pagarme-api.php
+++ b/includes/class-wc-pagarme-api.php
@@ -674,8 +674,8 @@ class WC_Pagarme_API {
 				'result' => 'fail',
 			);
 		} else {
+
 			// Save transaction data.
-			update_post_meta( $order->id, '_wc_pagarme_transaction_id', intval( $transaction['id'] ) );
 			$payment_data = array_map(
 				'sanitize_text_field',
 				array(
@@ -686,12 +686,41 @@ class WC_Pagarme_API {
 					'boleto_url'      => $transaction['boleto_url'],
 				)
 			);
-			update_post_meta( $order->id, '_wc_pagarme_transaction_data', $payment_data );
-			update_post_meta( $order->id, '_transaction_id', intval( $transaction['id'] ) );
-			$this->save_order_meta_fields( $order->id, $transaction );
 
-			// Change the order status.
-			$this->process_order_status( $order, $transaction['status'] );
+			//save meta data
+			$meta_data = array(
+				__( 'Banking Ticket URL', 'woocommerce-pagarme' ) => sanitize_text_field( $transaction['boleto_url'] ),
+				__( 'Credit Card', 'woocommerce-pagarme' )        => $this->get_card_brand_name( sanitize_text_field( $transaction['card_brand'] ) ),
+				__( 'Installments', 'woocommerce-pagarme' )       => sanitize_text_field( $transaction['installments'] ),
+				__( 'Total paid', 'woocommerce-pagarme' )         => number_format( intval( $transaction['amount'] ) / 100, wc_get_price_decimals(), wc_get_price_decimal_separator(), wc_get_price_thousand_separator() ),
+				__( 'Anti Fraud Score', 'woocommerce-pagarme' )   => sanitize_text_field( $transaction['antifraud_score'] ),
+				'_wc_pagarme_transaction_data'                    => $payment_data,
+				'_wc_pagarme_transaction_id'                      => intval( $transaction['id'] ),
+				'_transaction_id'                                 => intval( $transaction['id'] ),
+			);
+
+			// WooCommerce 3.0 or later.
+			if ( method_exists( $order, 'update_meta_data' ) ) {
+				foreach ( $meta_data as $key => $value ) {
+					if ( ! empty( $value ) ) {
+						$order->update_meta_data( $key, $value );
+					}
+				}
+
+				// Change the order status after all meta is added to order object
+				$this->process_order_status( $order, $transaction['status'] );
+			} else {
+
+				// Change the order status before updating metas directly into db
+				$this->process_order_status( $order, $transaction['status'] );
+
+				foreach ( $meta_data as $key => $value ) {
+					if ( ! empty( $value ) ) {
+						update_post_meta( $order_id, $key, $value );
+					}
+				}
+			}
+
 
 			// Empty the cart.
 			WC()->cart->empty_cart();


### PR DESCRIPTION
### Motivação
Em alguns casos (raros) o processamento do pedido no Woocommerce é mais lento que o IPN de resposta do pedido pago, sendo que, quando o IPN chega no servidor ele ainda não salvou a meta key `_wc_pagarme_transaction_id` do pedido fazendo com que o processamento do IPN falhe.

Mas, mesmo falhando, o IPN retorna um status 200 fazendo com que o Pagar.me conclua que o IPN foi processado corretamente e não envie retentativas.

### Solução proposta
- Retornar `false` na função `process_successful_ipn` caso o pedido com `_wc_pagarme_transaction_id` não seja encontrado.
- Retornar header `HTTP/1.1 406 Not Acceptable` informando para o Pagar.me que o IPN falhou. Assim o Pagar.me tentará enviar novamente o IPN sincronizando corretamente o status do pedido.

Obs: também foram adicionados mais alguns logs para debug dessa parte do código.