### PR TITLE
Adiciona testes automáticos para compras com cartão de crédito no checkout transparente 

### DIFF
--- a/bin/bash.php
+++ b/bin/bash.php
@@ -59,6 +59,26 @@ if (!$apiKey && !$encryptionKey) {
     $encryptionKey = $companyData->encryption_key->test;
 }
 
+/**
+ * Get customs options
+ *
+ * @param array $arguments Array of arguments passed to script
+ * @param string $name Name argument
+ *
+ * @return array
+ */
+function getCustomOptions($arguments, $name)
+{
+    $options = [];
+    $index = array_search($name, $arguments);
+
+    if ($index !== false && isset($arguments[$index++])) {
+        parse_str($arguments[$index], $options);
+    }
+
+    return $options;
+}
+
 define('PAGARME_API_KEY', $apiKey);
 define('PAGARME_ENCRYPTION_KEY', $encryptionKey);
 
@@ -80,22 +100,32 @@ $baseOptions = [
     'debug' => 'yes'
 ];
 
-$woocommerceCreditCardOptions = array_merge($baseOptions, [
-    'title' => 'Cartão de crédito',
-    'description' => 'Cartão de crédito Pagar.me',
-    'integration' => '',
-    'checkout' => 'no',
-    'max_installment' => '12',
-    'smallest_installment' => '1',
-    'interest_rate' => '5',
-    'free_installments' => '2',
-]);
+$optionsCustoms = getCustomOptions($argv, '--credit');
+$woocommerceCreditCardOptions = array_merge(
+    $baseOptions,
+    [
+        'title' => 'Cartão de crédito',
+        'description' => 'Cartão de crédito Pagar.me',
+        'integration' => '',
+        'checkout' => 'no',
+        'max_installment' => '12',
+        'smallest_installment' => '1',
+        'interest_rate' => '5',
+        'free_installments' => '2',
+    ],
+    $optionsCustoms
+);
 
-$woocommerceBoletoOptions = array_merge($baseOptions, [
-    'title' => 'Boleto bancário',
-    'description' => 'Pagar com boleto bancário',
-    'async' => 'no',
-]);
+$optionsCustoms = getCustomOptions($argv, '--boleto');
+$woocommerceBoletoOptions = array_merge(
+    $baseOptions,
+    [
+        'title' => 'Boleto bancário',
+        'description' => 'Pagar com boleto bancário',
+        'async' => 'no',
+    ],
+    $optionsCustoms
+);
 
 echo setup(WCP_CREDITCARD_OPTION_NAME, $woocommerceCreditCardOptions);
 echo setup(WCP_BOLETO_OPTION_NAME, $woocommerceBoletoOptions);

--- a/bin/bash.php
+++ b/bin/bash.php
@@ -1,131 +1,134 @@
 <?php
+/**
+ * Pagar.me API Auxiliary file
+ *
+ * @package bin/bash
+ */
 
 /**
  * Update Woocommerce Pagar.me Options
  *
- * @param string $optionName Option name
- * @param array $options Values to update
+ * @param string $option_name Option name.
+ * @param array  $options     Values to update.
  *
  * @return string
  */
-function setup($optionName, $options)
-{
-    $command = sprintf(
-        "wp option update %s '%s' --format=json --allow-root",
-        $optionName,
-        json_encode($options)
-    );
+function setup( $option_name, $options ) {
+	$command = sprintf(
+		"wp option update %s '%s' --format=json --allow-root",
+		$option_name,
+		json_encode( $options )
+	);
 
-    return shell_exec($command);
+	return shell_exec( $command );
 }
 
 /**
  * Creates and retrieve data from company temporary route
  *
  * @return stdClass
+ * @throws Exception Emits Exception in case of an error in Datetime.
  */
-function getCompanyTemporary()
-{
-    $ch = curl_init();
-    curl_setopt(
-        $ch,
-        CURLOPT_URL,
-        "https://api.pagar.me/1/companies/temporary"
-    );
-    date_default_timezone_set('America/Sao_Paulo');
-    $params = sprintf(
-        'name=acceptance_test_company&email=%s@woocoomercesuite.com&password=password',
-        date('YmdHis')
-    );
-    curl_setopt($ch, CURLOPT_POST, 1);
-    curl_setopt(
-        $ch,
-        CURLOPT_POSTFIELDS,
-        $params
-    );
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    $result = curl_exec($ch);
-    $companyData = json_decode($result);
-    curl_close($ch);
+function get_company_temporary() {
+	$ch = curl_init();
+	curl_setopt(
+		$ch,
+		CURLOPT_URL,
+		'https://api.pagar.me/1/companies/temporary'
+	);
+	$date   = new DateTime( 'now', new DateTimeZone( 'America/New_York' ) );
+	$params = sprintf(
+		'name=acceptance_test_company&email=%s@woocoomercesuite.com&password=password',
+		$date->format( 'YmdHis' )
+	);
+	curl_setopt( $ch, CURLOPT_POST, 1 );
+	curl_setopt(
+		$ch,
+		CURLOPT_POSTFIELDS,
+		$params
+	);
+	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+	$result       = curl_exec( $ch );
+	$company_data = json_decode( $result );
+	curl_close( $ch );
 
-    return $companyData;
+	return $company_data;
 }
-$apiKey = getenv('API_KEY');
-$encryptionKey = getenv('ENCRYPTION_KEY');
+$api_key        = getenv( 'API_KEY' );
+$encryption_key = getenv( 'ENCRYPTION_KEY' );
 
-if (!$apiKey && !$encryptionKey) {
-    $companyData = getCompanyTemporary();
-    $apiKey = $companyData->api_key->test;
-    $encryptionKey = $companyData->encryption_key->test;
+if ( ! $api_key && ! $encryption_key ) {
+	$company_data   = get_company_temporary();
+	$api_key        = $company_data->api_key->test;
+	$encryption_key = $company_data->encryption_key->test;
 }
 
 /**
  * Get customs options
  *
- * @param array $arguments Array of arguments passed to script
- * @param string $name Name argument
+ * @param array  $arguments Array of arguments passed to script.
+ * @param string $name      Name argument.
  *
  * @return array
  */
-function getCustomOptions($arguments, $name)
-{
-    $options = [];
-    $index = array_search($name, $arguments);
+function get_custom_options( $arguments, $name ) {
+	$options = [];
+	$index   = array_search( $name, $arguments );
 
-    if ($index !== false && isset($arguments[$index++])) {
-        parse_str($arguments[$index], $options);
-    }
+	if ( false !== $index && isset( $arguments[ $index++ ] ) ) {
+		parse_str( $arguments[ $index ], $options );
+	}
 
-    return $options;
+	return $options;
 }
 
-define('PAGARME_API_KEY', $apiKey);
-define('PAGARME_ENCRYPTION_KEY', $encryptionKey);
+define( 'PAGARME_API_KEY', $api_key );
+define( 'PAGARME_ENCRYPTION_KEY', $encryption_key );
 
 define(
-    'WCP_CREDITCARD_OPTION_NAME',
-    'woocommerce_pagarme-credit-card_settings'
+	'WCP_CREDITCARD_OPTION_NAME',
+	'woocommerce_pagarme-credit-card_settings'
 );
 
 define(
-    'WCP_BOLETO_OPTION_NAME',
-    'woocommerce_pagarme-banking-ticket_settings'
+	'WCP_BOLETO_OPTION_NAME',
+	'woocommerce_pagarme-banking-ticket_settings'
 );
 
-$baseOptions = [
-    'enabled' => 'yes',
-    'api_key' => PAGARME_API_KEY,
-    'encryption_key' => PAGARME_ENCRYPTION_KEY,
-    'testing' => 'yes',
-    'debug' => 'yes'
+$base_options = [
+	'enabled'        => 'yes',
+	'api_key'        => PAGARME_API_KEY,
+	'encryption_key' => PAGARME_ENCRYPTION_KEY,
+	'testing'        => 'yes',
+	'debug'          => 'yes',
 ];
 
-$optionsCustoms = getCustomOptions($argv, '--credit');
-$woocommerceCreditCardOptions = array_merge(
-    $baseOptions,
-    [
-        'title' => 'Cartão de crédito',
-        'description' => 'Cartão de crédito Pagar.me',
-        'integration' => '',
-        'checkout' => 'no',
-        'max_installment' => '12',
-        'smallest_installment' => '1',
-        'interest_rate' => '5',
-        'free_installments' => '2',
-    ],
-    $optionsCustoms
+$options_customs                 = get_custom_options( $argv, '--credit' );
+$woocommerce_credit_card_options = array_merge(
+	$base_options,
+	[
+		'title'                => 'Cartão de crédito',
+		'description'          => 'Cartão de crédito Pagar.me',
+		'integration'          => '',
+		'checkout'             => 'no',
+		'max_installment'      => '12',
+		'smallest_installment' => '1',
+		'interest_rate'        => '5',
+		'free_installments'    => '2',
+	],
+	$options_customs
 );
 
-$optionsCustoms = getCustomOptions($argv, '--boleto');
-$woocommerceBoletoOptions = array_merge(
-    $baseOptions,
-    [
-        'title' => 'Boleto bancário',
-        'description' => 'Pagar com boleto bancário',
-        'async' => 'no',
-    ],
-    $optionsCustoms
+$options_customs            = get_custom_options( $argv, '--boleto' );
+$woocommerce_boleto_options = array_merge(
+	$base_options,
+	[
+		'title'       => 'Boleto bancário',
+		'description' => 'Pagar com boleto bancário',
+		'async'       => 'no',
+	],
+	$options_customs
 );
 
-echo setup(WCP_CREDITCARD_OPTION_NAME, $woocommerceCreditCardOptions);
-echo setup(WCP_BOLETO_OPTION_NAME, $woocommerceBoletoOptions);
+echo setup( WCP_CREDITCARD_OPTION_NAME, $woocommerce_credit_card_options );
+echo setup( WCP_BOLETO_OPTION_NAME, $woocommerce_boleto_options );

--- a/composer.json
+++ b/composer.json
@@ -5,24 +5,26 @@
   "type": "wordpress-plugin",
   "license": "GPL-2.0+",
   "require": {
-    "composer/installers": "~1.0"
+    "composer/installers": "~1.0",
+    "ext-json": "*",
+    "ext-curl": "*"
   },
   "require-dev": {
     "claudiosanches/wp-git-hooks": "*",
     "squizlabs/php_codesniffer": "^3.4"
   },
-	"scripts": {
-		"pre-update-cmd": [
-			"ClaudioSanches\\WpGitHooks\\Hooks::preHooks"
-		],
-		"pre-install-cmd": [
-			"ClaudioSanches\\WpGitHooks\\Hooks::preHooks"
-		],
-		"post-install-cmd": [
-			"ClaudioSanches\\WpGitHooks\\Hooks::postHooks"
-		],
-		"post-update-cmd": [
-			"ClaudioSanches\\WpGitHooks\\Hooks::postHooks"
-		]
-	}
+  "scripts": {
+    "pre-update-cmd": [
+      "ClaudioSanches\\WpGitHooks\\Hooks::preHooks"
+    ],
+    "pre-install-cmd": [
+      "ClaudioSanches\\WpGitHooks\\Hooks::preHooks"
+    ],
+    "post-install-cmd": [
+      "ClaudioSanches\\WpGitHooks\\Hooks::postHooks"
+    ],
+    "post-update-cmd": [
+      "ClaudioSanches\\WpGitHooks\\Hooks::postHooks"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.12",
   "title": "WooCommerce Pagar.me",
   "description": "WooCommerce Pagar.me payment gateway",
-  "homepage": "",
   "main": "Gruntfile.js",
   "repository": {
     "type": "git",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,4 +18,8 @@
 	</rule>
 	<exclude-pattern>vendor</exclude-pattern>
 	<exclude-pattern>assets</exclude-pattern>
+
+	<rule ref="WordPress.Security.EscapeOutput">
+		<exclude-pattern>bin/bash.php</exclude-pattern>
+	</rule>
 </ruleset>

--- a/tests/e2e/boleto.spec.js
+++ b/tests/e2e/boleto.spec.js
@@ -1,10 +1,10 @@
 context('Boleto', () => {
   describe('when create a purchase with boleto as payment method', () => {
     before(() => {
-      cy.addToCart()
+      cy.addProductToCart()
       cy.goToCheckoutPage()
       cy.fillCheckoutForm()
-      cy.selectBoleto()
+      cy.selectBankingTicket()
       cy.placeOrder()
     })
 
@@ -14,8 +14,7 @@ context('Boleto', () => {
     })
 
     it('should countains boleto url', () => {
-      cy
-        .contains('Pagar boleto bancário')
+      cy.contains('Pagar boleto bancário')
         .and('have.attr', 'href', 'https://pagar.me' )
     })
   })

--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -3,7 +3,7 @@ context('Checkout Pagarme', () => {
     before(() => {
       cy.loginAsAdmin()
       cy.enableCheckoutPagarme()
-      cy.addToCart()
+      cy.addProductToCart()
       cy.goToCheckoutPage()
       cy.fillCheckoutForm()
       cy.selectCreditCard()

--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -7,10 +7,14 @@ context('Checkout Pagarme', () => {
       cy.goToCheckoutPage()
       cy.fillCheckoutForm()
       cy.selectCreditCard()
-      cy.wait(2000)
       cy.placeOrder()
 
       cy.fillPagarMeCheckoutCreditCardForm(1)
+    })
+
+    after(() => {
+      cy.loginAsAdmin()
+      cy.disableCheckoutPagarme()
     })
 
     it('should be at order received page', () => {

--- a/tests/e2e/credit_card.spec.js
+++ b/tests/e2e/credit_card.spec.js
@@ -1,0 +1,23 @@
+import checkoutData from './fixtures/data'
+
+context('Credit card', () => {
+  describe('Basic purchase workflow', () => {
+    before(() => {
+      cy.addProductToCart()
+      cy.goToCheckoutPage()
+      cy.fillCheckoutForm()
+      cy.selectCreditCard()
+      cy.fillCreditCardForm()
+      cy.placeOrder()
+    })
+
+    it('should be at order received page', () => {
+      cy.url().should('include', '/finalizar-compra/order-received/')
+      cy.contains('Pedido recebido')
+    })
+
+    it('should countains success message', () => {
+      cy.contains('Pagamento realizado utilizando cartão de crédito')
+    })
+  })
+})

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,6 +1,6 @@
 import checkoutData from '../fixtures/data'
 
-Cypress.Commands.add('addToCart', () => {
+Cypress.Commands.add('addProductToCart', () => {
   cy.log('Adding product to cart...')
 
   cy.visit('/product/hoodie-with-zipper/')
@@ -21,9 +21,11 @@ Cypress.Commands.add('fillCheckoutForm', () => {
   cy.log('Filling customer data...')
 
   cy.get('#billing_first_name')
+    .clear()
     .type(checkoutData.customer.name)
 
   cy.get('#billing_last_name')
+    .clear()
     .type(checkoutData.customer.lastname)
 
   cy.get('#billing_persontype')
@@ -32,6 +34,7 @@ Cypress.Commands.add('fillCheckoutForm', () => {
     })
 
   cy.get('#billing_cpf')
+    .clear()
     .type(checkoutData.customer.documents[0].number)
 
   cy.get('#billing_state')
@@ -40,18 +43,23 @@ Cypress.Commands.add('fillCheckoutForm', () => {
     })
 
   cy.get('#billing_postcode')
+    .clear()
     .type(checkoutData.address.zipcode)
 
   cy.get('#billing_address_1')
+    .clear()
     .type(checkoutData.address.street)
 
   cy.get('#billing_number')
+    .clear()
     .type(checkoutData.address.street_number)
 
   cy.get('#billing_neighborhood')
+    .clear()
     .type(checkoutData.address.neighborhood)
 
   cy.get('#billing_city')
+    .clear()
     .type(checkoutData.address.city)
 
   cy.get('#billing_country')
@@ -60,10 +68,12 @@ Cypress.Commands.add('fillCheckoutForm', () => {
     })
 
   cy.get('#billing_phone')
+    .clear()
     .type(checkoutData.customer.phone_numbers[0])
 
   cy.get('#billing_cellphone')
-    .type(checkoutData.customer.phone_numbers[0])
+    .clear()
+    .type(checkoutData.customer.phone_numbers[1])
 
   cy.get('#billing_email')
     .clear()
@@ -75,21 +85,27 @@ Cypress.Commands.add('fillCheckoutForm', () => {
 Cypress.Commands.add('pagarmeCheckoutCreditCardForm', (iframeSelector, elSelector) => {
   return cy
     .get(`iframe${iframeSelector || ''}`, { timeout: 60000 })
-  .then($iframe => {
-    return cy.wrap($iframe.contents().find('#pagarme-modal-box-step-credit-card-information'))
-  })
+    .then($iframe => {
+      return cy.wrap($iframe.contents().find('#pagarme-modal-box-step-credit-card-information'))
+    })
 })
 
 Cypress.Commands.add('selectCreditCard', () => {
-  cy
-   .get('#payment_method_pagarme-credit-card')
-   .click({ force: true })
+  cy.log('Select payment method credt card')
+
+  cy.get('#payment_method_pagarme-credit-card')
+    .next()
+    .contains('Cartão de crédito')
+    .click()
 })
 
-Cypress.Commands.add('selectBoleto', () => {
-  cy
-   .get('#payment_method_pagarme-banking-ticket')
-   .click({ force: true })
+Cypress.Commands.add('selectBankingTicket', () => {
+  cy.log('Select payment method banking ticket')
+
+  cy.get('#payment_method_pagarme-banking-ticket')
+    .next()
+    .contains('Boleto bancário')
+    .click()
 })
 
 Cypress.Commands.add('fillPagarMeCheckoutCreditCardForm', (installments) => {
@@ -98,8 +114,8 @@ Cypress.Commands.add('fillPagarMeCheckoutCreditCardForm', (installments) => {
   cy.pagarmeCheckoutCreditCardForm().as('pagarmeModal')
 
   cy.get('@pagarmeModal')
-   .find('#pagarme-modal-box-credit-card-number')
-   .type(checkoutData.card_number)
+    .find('#pagarme-modal-box-credit-card-number')
+    .type(checkoutData.card_number)
 
   cy.get('@pagarmeModal')
     .find('#pagarme-modal-box-credit-card-name')
@@ -128,11 +144,12 @@ Cypress.Commands.add('placeOrder', () => {
 })
 
 Cypress.Commands.add('loginAsAdmin', () => {
-  cy.visit('/wp-admin');
+  cy.visit('/wp-admin')
   cy.wait(1000)
-  cy.get('#user_login').type('pagarme');
-  cy.get('#user_pass').type('wordpress');
-  cy.get('#wp-submit').click();
+
+  cy.get('#user_login').type('pagarme')
+  cy.get('#user_pass').type('wordpress')
+  cy.get('#wp-submit').click()
 })
 
 Cypress.Commands.add('enableCheckoutPagarme', () => {

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -139,7 +139,8 @@ Cypress.Commands.add('fillPagarMeCheckoutCreditCardForm', (installments) => {
 })
 
 Cypress.Commands.add('placeOrder', () => {
-  cy.get('button[name="woocommerce_checkout_place_order"]')
+  cy.get('#place_order')
+    .contains('Finalizar compra')
     .click()
 })
 
@@ -159,5 +160,43 @@ Cypress.Commands.add('enableCheckoutPagarme', () => {
     .check()
 
   cy.get('.woocommerce-save-button')
+    .contains('Salvar alterações')
     .click()
+})
+
+Cypress.Commands.add('disableCheckoutPagarme', () => {
+  cy.visit('/wp-admin/admin.php?page=wc-settings&tab=checkout&section=wc_pagarme_credit_card_gateway')
+
+  cy.get('#woocommerce_pagarme-credit-card_checkout')
+    .uncheck()
+
+  cy.get('.woocommerce-save-button')
+    .contains('Salvar alterações')
+    .click()
+})
+
+Cypress.Commands.add('fillAvoidingException', (element, value) => {
+  cy.on('uncaught:exception', () => {
+      return false
+    })
+    .get(element)
+    .type(value)
+})
+
+Cypress.Commands.add('fillCreditCardForm', () => {
+  cy.log('Filling credit card data...')
+
+  cy.fillAvoidingException(
+    '#pagarme-card-holder-name',
+    checkoutData.card_holder_name
+  )
+
+  cy.get('#pagarme-card-number')
+    .type(checkoutData.card_number)
+
+  cy.get('#pagarme-card-expiry')
+    .type(checkoutData.card_expiration_date)
+
+  cy.get('#pagarme-card-cvc')
+    .type(checkoutData.card_cvv)
 })


### PR DESCRIPTION
Esse PR adiciona teste para o fluxo de finalização de pedido utilizando cartão de crédito

Os testes validam os seguintes itens:

 1. Wordpress precisa estar na página de compra finalizada.
 2. A página deve conter o texto "Pedido recebido" - Etapa baseada no tema storefront
 3. A página deve conter a mensagem de sucesso "Pagamento realizado utilizando cartão de crédito"