### PR TITLE
credit_card: add default installment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # WooCommerce Pagar.me #
-**Contributors:** pagarme, claudiosanches  
-**Tags:** woocommerce, pagarme, payment  
-**Requires at least:** 4.0  
-**Tested up to:** 5.1  
-**Stable tag:** 2.0.13  
-**License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**Contributors:** pagarme, claudiosanches
+**Tags:** woocommerce, pagarme, payment
+**Requires at least:** 4.0
+**Tested up to:** 5.1
+**Stable tag:** 2.0.14
+**License:** GPLv2 or later
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Receba pagamentos por cartão de crédito e boleto bancário utilizando o Pagar.me
 
@@ -124,6 +124,10 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 
 
 ## Changelog ##
+
+### 2.0.14 - 2018/05/02 ###
+
+* Corrigido problema de resetar para 1 parcela ao recarregar o formulário de dados de cartão.
 
 ### 2.0.13 - 2018/05/29 ###
 

--- a/includes/class-wc-pagarme-api.php
+++ b/includes/class-wc-pagarme-api.php
@@ -326,6 +326,7 @@ class WC_Pagarme_API {
 			if ( apply_filters( 'wc_pagarme_allow_credit_card_installments_validation', isset( $posted['pagarme_installments'] ), $order ) ) {
 				$_installment = $posted['pagarme_installments'];
 
+				$data['installments'] = $_installment;
 				// Get installments data.
 				$installments = $this->get_installments( $order->get_total() );
 				if ( isset( $installments[ $_installment ] ) ) {
@@ -333,8 +334,7 @@ class WC_Pagarme_API {
 					$smallest_installment = $this->get_smallest_installment();
 
 					if ( $installment['installment'] <= $this->gateway->max_installment && $smallest_installment <= $installment['installment_amount'] ) {
-						$data['installments'] = $installment['installment'];
-						$data['amount']       = $installment['amount'];
+						$data['amount'] = $installment['amount'];
 					}
 				}
 			}

--- a/languages/woocommerce-pagarme.pot
+++ b/languages/woocommerce-pagarme.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Pagar.me 2.0.13\n"
+"Project-Id-Version: WooCommerce Pagar.me 2.0.14\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-pagarme\n"
-"POT-Creation-Date: 2019-04-29 20:05:38+00:00\n"
+"POT-Creation-Date: 2019-05-02 13:10:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -465,15 +465,19 @@ msgstr ""
 msgid "CVC"
 msgstr ""
 
-#: templates/credit-card/payment-form.php:44
+#: templates/credit-card/payment-form.php:38
+msgid "Please, select the number of installments"
+msgstr ""
+
+#: templates/credit-card/payment-form.php:45
 msgid "(total of %s)"
 msgstr ""
 
-#: templates/credit-card/payment-form.php:44
+#: templates/credit-card/payment-form.php:45
 msgid "(interest-free)"
 msgstr ""
 
-#: templates/credit-card/payment-form.php:47
+#: templates/credit-card/payment-form.php:48
 msgid "%1$dx of %2$s %3$s"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pagarme, claudiosanches
 Tags: woocommerce, pagarme, payment
 Requires at least: 4.0
 Tested up to: 5.1
-Stable tag: 2.0.13
+Stable tag: 2.0.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -116,6 +116,10 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 4. Configurações para cartão de crédito.
 
 == Changelog ==
+
+= 2.0.14 - 2018/05/02 =
+
+* Corrigido problema de resetar para 1 parcela ao recarregar o formulário de dados de cartão.
 
 = 2.0.13 - 2018/05/29 =
 

--- a/templates/credit-card/payment-form.php
+++ b/templates/credit-card/payment-form.php
@@ -35,6 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<p class="form-row form-row-wide">
 			<label for="pagarme-card-installments"><?php esc_html_e( 'Installments', 'woocommerce-pagarme' ); ?> <span class="required">*</span></label>
 			<select name="pagarme_installments" id="pagarme-installments" style="font-size: 1.5em; padding: 8px; width: 100%;">
+				<option value="0"><?php printf( esc_html__( 'Please, select the number of installments', 'woocommerce-pagarme' ) ); ?></option>
 				<?php
 				foreach ( $installments as $number => $installment ) :
 					if ( 1 !== $number && $smallest_installment > $installment['installment_amount'] ) {
@@ -43,7 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 					$interest           = ( ( $cart_total * 100 ) < $installment['amount'] ) ? sprintf( __( '(total of %s)', 'woocommerce-pagarme' ), strip_tags( wc_price( $installment['amount'] / 100 ) ) ) : __( '(interest-free)', 'woocommerce-pagarme' );
 					$installment_amount = strip_tags( wc_price( $installment['installment_amount'] / 100 ) );
-				?>
+					?>
 				<option value="<?php echo absint( $installment['installment'] ); ?>"><?php printf( esc_html__( '%1$dx of %2$s %3$s', 'woocommerce-pagarme' ), absint( $installment['installment'] ), esc_html( $installment_amount ), esc_html( $interest ) ); ?></option>
 				<?php endforeach; ?>
 			</select>

--- a/tests/e2e/credit_card.spec.js
+++ b/tests/e2e/credit_card.spec.js
@@ -14,7 +14,7 @@ context('Credit card', () => {
     })
 
     it('should be at order received page', () => {
-      cy.url().should('include', '/finalizar-compra/order-received/')
+      cy.url({ timeout: 60000 }).should('include', '/finalizar-compra/order-received/')
       cy.contains('Pedido recebido')
     })
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -278,5 +278,8 @@ Cypress.Commands.add('fillCreditCardForm', () => {
     .type(checkoutData.card_expiration_date)
 
   cy.get('#pagarme-card-cvc')
-    .type(checkoutData.card_cvv)
+	  .type(checkoutData.card_cvv)
+
+	cy.get('#pagarme-installments')
+	  .select(checkoutData.card_installments.toString())
 })

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -5,7 +5,7 @@
  * Description: Gateway de pagamento Pagar.me para WooCommerce.
  * Author: Pagar.me, Claudio Sanches
  * Author URI: https://pagar.me/
- * Version: 2.0.13
+ * Version: 2.0.14
  * License: GPLv2 or later
  * Text Domain: woocommerce-pagarme
  * Domain Path: /languages/
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '2.0.13';
+		const VERSION = '2.0.14';
 
 		/**
 		 * Instance of this class.


### PR DESCRIPTION
Após preencher os dados de cartão, caso algum campo seja corrigido, a template de cartão de crédito é carregada novamente, e o número de parcelas escolhida volta para "1".

Para corrigir isso, deixei como primeira opção um valor de parcela inválida, informando ao cliente para selecionar a parcela novamente. Caso ele não escolha a parcela, um erro será disparado e exibido. Vocês podem conferir o comportamento nesse gif:

![Woocommerce parcelas](https://user-images.githubusercontent.com/18074134/56920021-7ca0d880-6a98-11e9-8e6b-c966df99a5a4.gif)


Closes #85 