### PR TITLE
Adiciona teste automáticos de postback para última transação

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
       enabled: true
     steps:
       - checkout
+      - run:
+          name: Setup company temporary Pagar.me
+          command: make company-setup
       - persist_to_workspace:
             root: ~/project
             paths:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/
 cache/
 tests/e2e/videos
 tests/e2e/screenshots
+.env.*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ list:
 	@echo "prepare  | Setup WordPress, Woocommerce and Woocommerce-Pagar.me"
 	@echo "up       | Create and start containers"
 
-up:
+up: company-setup
 	docker-compose up -d
 
 wait-for-wordpress:
@@ -57,6 +57,10 @@ lint-js:
 test-e2e:
 	docker-compose run node bash -c \
 	'npm install && npx cypress install && npx cypress run'
+
+company-setup:
+	touch .env.local
+	docker-compose run composer php ./bin/setup-company-temporary.php
 
 down:
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ wp-install:
 	--admin_password=wordpress \
 	--path=/var/www/html \
 	&& docker-compose exec woopagarme wp core update --allow-root \
-	&& docker-compose exec woopagarme mkdir /var/www/html/wp-content/uploads/wc-logs \
+	&& docker-compose exec woopagarme touch /var/www/html/wp-content/uploads/wc-logs \
 	&& docker-compose exec woopagarme chown www-data:www-data -R /var/www/html/wp-content/uploads/wc-logs
 
 wp-setup:

--- a/bin/bash.php
+++ b/bin/bash.php
@@ -24,46 +24,6 @@ function setup( $option_name, $options ) {
 }
 
 /**
- * Creates and retrieve data from company temporary route
- *
- * @return stdClass
- * @throws Exception Emits Exception in case of an error in Datetime.
- */
-function get_company_temporary() {
-	$ch = curl_init();
-	curl_setopt(
-		$ch,
-		CURLOPT_URL,
-		'https://api.pagar.me/1/companies/temporary'
-	);
-	$date   = new DateTime( 'now', new DateTimeZone( 'America/New_York' ) );
-	$params = sprintf(
-		'name=acceptance_test_company&email=%s@woocoomercesuite.com&password=password',
-		$date->format( 'YmdHis' )
-	);
-	curl_setopt( $ch, CURLOPT_POST, 1 );
-	curl_setopt(
-		$ch,
-		CURLOPT_POSTFIELDS,
-		$params
-	);
-	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-	$result       = curl_exec( $ch );
-	$company_data = json_decode( $result );
-	curl_close( $ch );
-
-	return $company_data;
-}
-$api_key        = getenv( 'API_KEY' );
-$encryption_key = getenv( 'ENCRYPTION_KEY' );
-
-if ( ! $api_key && ! $encryption_key ) {
-	$company_data   = get_company_temporary();
-	$api_key        = $company_data->api_key->test;
-	$encryption_key = $company_data->encryption_key->test;
-}
-
-/**
  * Get customs options
  *
  * @param array  $arguments Array of arguments passed to script.
@@ -82,8 +42,8 @@ function get_custom_options( $arguments, $name ) {
 	return $options;
 }
 
-define( 'PAGARME_API_KEY', $api_key );
-define( 'PAGARME_ENCRYPTION_KEY', $encryption_key );
+define( 'PAGARME_API_KEY', getenv( 'API_KEY' ) );
+define( 'PAGARME_ENCRYPTION_KEY', getenv( 'ENCRYPTION_KEY' ) );
 
 define(
 	'WCP_CREDITCARD_OPTION_NAME',

--- a/bin/setup-company-temporary.php
+++ b/bin/setup-company-temporary.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Pagar.me API Auxiliary file to setup company temporary
+ *
+ * @package bin/bash
+ */
+
+/**
+ * Creates and retrieve data from company temporary route
+ *
+ * @return stdClass
+ * @throws Exception Emits Exception in case of an error in Datetime.
+ */
+function get_company_temporary() {
+	$ch = curl_init();
+	curl_setopt(
+		$ch,
+		CURLOPT_URL,
+		'https://api.pagar.me/1/companies/temporary'
+	);
+	$date   = new DateTime( 'now', new DateTimeZone( 'America/New_York' ) );
+	$params = sprintf(
+		'name=acceptance_test_company&email=%s@woocoomercesuite.com&password=password',
+		$date->format( 'YmdHis' )
+	);
+	curl_setopt( $ch, CURLOPT_POST, 1 );
+	curl_setopt(
+		$ch,
+		CURLOPT_POSTFIELDS,
+		$params
+	);
+	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+	$result       = curl_exec( $ch );
+	$company_data = json_decode( $result );
+	curl_close( $ch );
+
+	return $company_data;
+}
+
+$file_name      = '.env.local';
+$api_key        = getenv( 'API_KEY' );
+$encryption_key = getenv( 'ENCRYPTION_KEY' );
+$env_file       = file_exists( $file_name ) ? file_get_contents( $file_name ) : '';
+
+if ( ( ! $api_key && ! $encryption_key ) && strpos( $env_file, 'API_KEY=' ) === false ) {
+	$company_data   = get_company_temporary();
+	$api_key        = $company_data->api_key->test;
+	$encryption_key = $company_data->encryption_key->test;
+
+	echo "Create file .env.local\n";
+	$command = sprintf(
+		"API_KEY=%s\nENCRYPTION_KEY=%s\nCYPRESS_API_KEY=%s\nCYPRESS_ENCRYPTION_KEY=%s",
+		$api_key,
+		$encryption_key,
+		$api_key,
+		$encryption_key
+	);
+	shell_exec( "echo $'{$command}' > .env.local" );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
     ports:
       - 80:80
     restart: always
-    env_file: .env
+    env_file:
+      - .env
+      - .env.local
 
   composer:
     image: composer:1.8.4
@@ -33,3 +35,5 @@ services:
     volumes:
       - ./:/app
       - ./cache:/root/.cache/
+    env_file:
+      - .env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -3779,6 +3779,12 @@
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
+    "pagarme": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pagarme/-/pagarme-4.1.0.tgz",
+      "integrity": "sha512-SPDeqUGip+Gko10Us5m6v4y6+sHi0TVzu34N53heGov6w9LfzM4Ky8xHWV+JJxYZqy+C0vkegFNm/7tgxdQnOA==",
+      "dev": true
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-phpcs": "^0.4.0",
     "grunt-wp-i18n": "^0.5.3",
-    "grunt-wp-readme-to-markdown": "^1.0.0"
+    "grunt-wp-readme-to-markdown": "^1.0.0",
+    "pagarme": "^4.1.0"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/tests/e2e/credit_card.spec.js
+++ b/tests/e2e/credit_card.spec.js
@@ -1,5 +1,3 @@
-import checkoutData from './fixtures/data'
-
 context('Credit card', () => {
   describe('Basic purchase workflow', () => {
     before(() => {
@@ -18,7 +16,7 @@ context('Credit card', () => {
       cy.contains('Pedido recebido')
     })
 
-    it('should countains success message', () => {
+    it('should contains success message', () => {
       cy.contains('Pagamento realizado utilizando cartão de crédito')
     })
   })

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -11,7 +11,36 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
+const pagarme = require('pagarme')
+let client
+
+const getClient = (apiKey) => {
+  if (!client) {
+    client = pagarme.client.connect({ api_key: apiKey })
+  }
+
+  return client
+}
+
+const getLastTransaction = (apiKey) =>
+  getClient(apiKey)
+    .then(client => client.transactions.all({ count: 1 }))
+    .then(transactions => transactions[0])
+
+const getLastTransactionPostback = (apiKey) =>
+  getLastTransaction(apiKey)
+    .then(transaction => transaction.id)
+    .then(id =>
+      getClient(apiKey)
+        .then(client => client.postbacks.find({ transactionId: id }))
+    )
+
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
+
+  on('task', {
+    'pagarmejs:transaction': () => getLastTransaction(config.env.API_KEY),
+    'pagarmejs:postback': () => getLastTransactionPostback(config.env.API_KEY)
+  })
 }

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -1,0 +1,18 @@
+context('Postback', () => {
+  describe('Update purchase with postback', () => {
+    let postback;
+
+    it('Get postbacks', () => {
+      cy.task('pagarmejs:postback')
+        .then(postbacks => {
+          expect(postbacks).to.not.be.empty
+          postback = postbacks[0]
+        })
+    })
+
+    it('Postback is valid', () => {
+      expect(postback).to.have
+        .property('request_url', 'http://woopagarme/wc-api/WC_Pagarme_Credit_Card_Gateway/')
+    })
+  })
+})

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -1,8 +1,24 @@
-context('Postback', () => {
-  describe('Update purchase with postback', () => {
-    let postback;
+context('Postback last transaction', () => {
+  describe('when you update a purchase with postback', () => {
+    let postback
 
-    it('Get postbacks', () => {
+    before(() => {
+      cy.configureCreditCard({ checkout: false })
+      cy.addProductToCart()
+      cy.goToCheckoutPage()
+      cy.fillCheckoutForm()
+      cy.selectCreditCard()
+      cy.fillCreditCardForm()
+      cy.placeOrder()
+    })
+
+    it('should be at order received page', () => {
+      cy.url({ timeout: 60000 })
+        .should('include', '/finalizar-compra/order-received/')
+      cy.contains('Pedido recebido')
+    })
+
+    it('should contain at least one postback', () => {
       cy.task('pagarmejs:postback')
         .then(postbacks => {
           expect(postbacks).to.not.be.empty
@@ -10,9 +26,21 @@ context('Postback', () => {
         })
     })
 
-    it('Postback is valid', () => {
+    it('Postback URL should equals test domain', () => {
       expect(postback).to.have
         .property('request_url', 'http://woopagarme/wc-api/WC_Pagarme_Credit_Card_Gateway/')
+    })
+
+    it('should update order transaction via postback', () => {
+      cy.request({
+          method: 'POST',
+          url: 'wc-api/WC_Pagarme_Credit_Card_Gateway/',
+          headers: JSON.parse(postback.headers),
+          body: postback.payload
+        })
+        .then((response) => {
+          expect(response.status).to.eq(200)
+        })
     })
   })
 })

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -1,6 +1,7 @@
 context('Postback last transaction', () => {
   describe('when you update a purchase with postback', () => {
     let postback
+    let orderId
 
     before(() => {
       cy.configureCreditCard({ checkout: false })
@@ -23,12 +24,22 @@ context('Postback last transaction', () => {
         .then(postbacks => {
           expect(postbacks).to.not.be.empty
           postback = postbacks[0]
+
+          cy.getPayloadData(postback.payload)
+            .then((payload) => {
+              orderId = payload['transaction[metadata][order_number]']
+            })
         })
     })
 
     it('Postback URL should equals test domain', () => {
       expect(postback).to.have
         .property('request_url', 'http://woopagarme/wc-api/WC_Pagarme_Credit_Card_Gateway/')
+    })
+
+    it('should validate the current status of the order', () => {
+      cy.visit(`http://woopagarme/minha-conta/view-order/${orderId}/`)
+        .contains('atualmente está Aguardando.')
     })
 
     it('should update order transaction via postback', () => {
@@ -40,6 +51,19 @@ context('Postback last transaction', () => {
         })
         .then((response) => {
           expect(response.status).to.eq(200)
+        })
+    })
+
+    it('should validate the new status of the order', () => {
+      const status = {
+        paid: 'Processando',
+        refused: 'Malsucedido'
+      }
+
+      cy.getPayloadData(postback.payload)
+        .then((payload) => {
+          cy.visit(`http://woopagarme/minha-conta/view-order/${orderId}/`)
+          cy.contains('atualmente está ' + status[payload['current_status']])
         })
     })
   })

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -283,3 +283,13 @@ Cypress.Commands.add('fillCreditCardForm', () => {
 	cy.get('#pagarme-installments')
 	  .select(checkoutData.card_installments.toString())
 })
+
+Cypress.Commands.add('getPayloadData', (payload) => {
+  const items = {}
+  payload.split('&').forEach(element => {
+    const [prop = '', value = ''] = element.split('=')
+    items[decodeURIComponent(prop)] = decodeURIComponent(value)
+  })
+
+  return items
+})


### PR DESCRIPTION
Esse PR adiciona teste para o fluxo de atualização de pedido via postback

Os testes validam os seguintes itens:

- Um novo pedido deve ser realizado
- A última transação registrada no Pagar.me deve possuí postback
- A url de postback deve ser no domínio de teste
- O status atual do pedido deve ser "aguardando"
- A atualização via postback deve ter tido sucesso 
- O status atualizado do pedido dever ser o mesmo do postback "processando" ou "malsucedido"

Obs: para a execução dos testes fora do container `node` deve exportar as variáveis de ambiente do arquivo `.env.local` criado na execução do comando `make company-setup` ou `make prepare`.

Ex.: `export CYPRESS_API_KEY=ak_test_API_KEY`