### PR TITLE
Adiciona testes automáticos de postback para transação recusada no checkout Pagar.me

### DIFF
--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -22,8 +22,11 @@ context('Checkout Pagarme', () => {
   })
 
   describe('when make a purchase with refused orders register enabled', () => {
+    let orderId
+    let postback
+
     before(() => {
-      cy.configureCreditCard({ register_refused_order: true })
+      cy.configureCreditCard({ checkout: true, register_refused_order: true })
       cy.addProductToCart()
       cy.goToCheckoutPage()
       cy.fillCheckoutForm()
@@ -34,7 +37,8 @@ context('Checkout Pagarme', () => {
     })
 
     it('should be at order received page', () => {
-      cy.url({ timeout: 60000 }).should('include', '/finalizar-compra/order-received/')
+      cy.url({ timeout: 60000 })
+        .should('include', '/finalizar-compra/order-received/')
       cy.contains('Pedido recebido')
     })
 
@@ -44,16 +48,33 @@ context('Checkout Pagarme', () => {
 
     it('should be registered at "my orders" page', () => {
       cy.get('.woocommerce-order-overview__order strong').then($order => {
-        const orderId = $order.text()
-        cy.visit('/minha-conta/orders/', { timeout: 60000 })
+        orderId = $order.text()
+        cy.visit('/minha-conta/orders/')
 
-        let orderUrl = `http://woopagarme/minha-conta/view-order/${orderId}/`
         cy.get('tbody', { timeout: 60000 })
           .contains(`#${orderId}`)
 
-        cy.visit(orderUrl, { timeout: 60000 })
+        cy.visit(`http://woopagarme/minha-conta/view-order/${orderId}/`)
           .contains(`Pedido #${orderId}`)
       })
+    })
+
+    it('should contain at least one postback', () => {
+      const opts = {
+        metadata: { order_number: orderId }
+      }
+
+      cy.log('Wait process transaction in Pagar.me')
+      cy.wait(5000)
+
+      cy.task('pagarmejs:transaction', opts)
+        .then((transaction) =>
+          cy.task('pagarmejs:postback', transaction.id)
+            .then((postbacks) => {
+              expect(postbacks).to.not.be.empty
+              postback = postbacks[0]
+            })
+        )
     })
   })
 })

--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -53,10 +53,13 @@ context('Checkout Pagarme', () => {
 
         cy.get('tbody', { timeout: 60000 })
           .contains(`#${orderId}`)
-
-        cy.visit(`http://woopagarme/minha-conta/view-order/${orderId}/`)
-          .contains(`Pedido #${orderId}`)
       })
+    })
+
+    it('should validate the current status of the order', () => {
+      cy.visit(`minha-conta/view-order/${orderId}/`)
+      cy.contains(`Pedido #${orderId}`)
+      cy.contains('atualmente está Aguardando.')
     })
 
     it('should contain at least one postback', () => {

--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -91,5 +91,12 @@ context('Checkout Pagarme', () => {
           expect(payload['current_status']).to.equal('refused')
         })
     })
+
+    it('should update order transaction via postback', () => {
+      cy.updateOrderViaPostback(postback)
+        .then((response) => {
+          expect(response.status).to.eq(200)
+        })
+    })
   })
 })

--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -79,5 +79,17 @@ context('Checkout Pagarme', () => {
             })
         )
     })
+
+    it('Postback URL should equals test domain', () => {
+      expect(postback).to.have
+        .property('request_url', 'http://woopagarme/wc-api/WC_Pagarme_Credit_Card_Gateway/')
+    })
+
+    it('Postback status should equals refused', () => {
+      cy.getPayloadData(postback.payload)
+        .then((payload) => {
+          expect(payload['current_status']).to.equal('refused')
+        })
+    })
   })
 })

--- a/tests/e2e/checkout-pagarme.spec.js
+++ b/tests/e2e/checkout-pagarme.spec.js
@@ -12,7 +12,8 @@ context('Checkout Pagarme', () => {
     })
 
     it('should be at order received page', () => {
-      cy.url({ timeout: 60000 }).should('include', '/finalizar-compra/order-received/')
+      cy.url({ timeout: 60000 })
+        .should('include', '/finalizar-compra/order-received/')
       cy.contains('Pedido recebido')
     })
 
@@ -47,13 +48,15 @@ context('Checkout Pagarme', () => {
     })
 
     it('should be registered at "my orders" page', () => {
-      cy.get('.woocommerce-order-overview__order strong').then($order => {
-        orderId = $order.text()
-        cy.visit('/minha-conta/orders/')
+      cy.get('.woocommerce-order-overview__order strong')
+        .then(($order) => $order.text())
+        .then((id) => {
+          orderId = id
+          cy.visit('/minha-conta/orders/')
 
-        cy.get('tbody', { timeout: 60000 })
-          .contains(`#${orderId}`)
-      })
+          cy.get('tbody', { timeout: 60000 })
+            .contains(`#${orderId}`)
+        })
     })
 
     it('should validate the current status of the order', () => {
@@ -67,7 +70,7 @@ context('Checkout Pagarme', () => {
         metadata: { order_number: orderId }
       }
 
-      cy.log('Wait process transaction in Pagar.me')
+      cy.log('Wait process transaction on Pagar.me')
       cy.wait(5000)
 
       cy.task('pagarmejs:transaction', opts)
@@ -97,6 +100,11 @@ context('Checkout Pagarme', () => {
         .then((response) => {
           expect(response.status).to.eq(200)
         })
+    })
+
+    it('should validate the new status of the order', () => {
+      cy.visit(`minha-conta/view-order/${orderId}/`)
+      cy.contains('atualmente está Malsucedido')
     })
   })
 })

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -22,6 +22,17 @@ const getClient = (apiKey) => {
   return client
 }
 
+const getTransaction = (apiKey, options) =>
+  getClient(apiKey)
+    .then(client => client.transactions.find(options))
+    .then(transactions => transactions[0])
+
+const getPostback = (apiKey, transactionId) =>
+  getClient(apiKey)
+    .then((client) =>
+      client.postbacks.find({ transactionId: transactionId})
+    )
+
 const getLastTransaction = (apiKey) =>
   getClient(apiKey)
     .then(client => client.transactions.all({ count: 1 }))
@@ -40,7 +51,9 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
 
   on('task', {
-    'pagarmejs:transaction': () => getLastTransaction(config.env.API_KEY),
-    'pagarmejs:postback': () => getLastTransactionPostback(config.env.API_KEY)
+    'pagarmejs:transaction': (options) => getTransaction(config.env.API_KEY, options),
+    'pagarmejs:postback': (transactionId) => getPostback(config.env.API_KEY, transactionId),
+    'pagarmejs:lastTransaction': () => getLastTransaction(config.env.API_KEY),
+    'pagarmejs:lastPostback': () => getLastTransactionPostback(config.env.API_KEY)
   })
 }

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -33,10 +33,7 @@ const getPostback = (apiKey, transactionId) =>
       client.postbacks.find({ transactionId: transactionId})
     )
 
-const getLastTransaction = (apiKey) =>
-  getClient(apiKey)
-    .then(client => client.transactions.all({ count: 1 }))
-    .then(transactions => transactions[0])
+const getLastTransaction = (apiKey) => getTransaction(apiKey, { count: 1 })
 
 const getLastTransactionPostback = (apiKey) =>
   getLastTransaction(apiKey)

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -43,12 +43,7 @@ context('Postback last transaction', () => {
     })
 
     it('should update order transaction via postback', () => {
-      cy.request({
-          method: 'POST',
-          url: 'wc-api/WC_Pagarme_Credit_Card_Gateway/',
-          headers: JSON.parse(postback.headers),
-          body: postback.payload
-        })
+      cy.updateOrderViaPostback(postback)
         .then((response) => {
           expect(response.status).to.eq(200)
         })

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -20,7 +20,7 @@ context('Postback last transaction', () => {
     })
 
     it('should contain at least one postback', () => {
-      cy.task('pagarmejs:postback')
+      cy.task('pagarmejs:lastPostback')
         .then(postbacks => {
           expect(postbacks).to.not.be.empty
           postback = postbacks[0]

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -38,7 +38,7 @@ context('Postback last transaction', () => {
     })
 
     it('should validate the current status of the order', () => {
-      cy.visit(`http://woopagarme/minha-conta/view-order/${orderId}/`)
+      cy.visit(`minha-conta/view-order/${orderId}/`)
         .contains('atualmente está Aguardando.')
     })
 
@@ -57,7 +57,7 @@ context('Postback last transaction', () => {
 
       cy.getPayloadData(postback.payload)
         .then((payload) => {
-          cy.visit(`http://woopagarme/minha-conta/view-order/${orderId}/`)
+          cy.visit(`minha-conta/view-order/${orderId}/`)
           cy.contains('atualmente está ' + status[payload['current_status']])
         })
     })

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -293,3 +293,12 @@ Cypress.Commands.add('getPayloadData', (payload) => {
 
   return items
 })
+
+Cypress.Commands.add('updateOrderViaPostback', (postback) =>
+  cy.request({
+    method: 'POST',
+    url: 'wc-api/WC_Pagarme_Credit_Card_Gateway/',
+    headers: JSON.parse(postback.headers),
+    body: postback.payload
+  })
+)


### PR DESCRIPTION
Esse PR adiciona testes para validação do postback de transação recusada no checkout Pagar.me

Os testes validam os seguintes itens:

- O status atual do pedido deve ser "aguardando"
- A transação registrada no Pagar.me deve possuí postback
- A url de postback deve ser no domínio de teste e o status 'refused'
- A atualização via postback deve ter tido sucesso
- O status atualizado do pedido dever ser "malsucedido"

Obs: para a execução dos testes fora do container `node` deve exportar as variáveis de ambiente do arquivo `.env.local` criado na execução do comando `make company-setup` ou `make prepare`.

Ex.: `export CYPRESS_API_KEY=ak_test_API_KEY`