### PR TITLE
Torna o campo bairro obrigatório

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Pagar.me for WooCommerce #
-**Contributors:** pagarme, claudiosanches  
+**Contributors:** pagarme, claudiosanches, murilohns  
 **Tags:** woocommerce, pagarme, payment  
 **Requires at least:** 4.0  
-**Tested up to:** 5.2  
-**Stable tag:** 2.2.0  
+**Tested up to:** 5.5  
+**Stable tag:** 2.3.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -125,6 +125,9 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 
 ## Changelog ##
 
+### 2.3.0 - 2020-11-05 ###
+
+* Torna o campo bairro obrigatório
 
 ### 2.2.0 - 2020-09-10 ###
 

--- a/languages/woocommerce-pagarme.pot
+++ b/languages/woocommerce-pagarme.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pagar.me for WooCommerce 2.1.0\n"
+"Project-Id-Version: Pagar.me for WooCommerce 2.3.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-pagarme\n"
-"POT-Creation-Date: 2020-09-10 18:27:49+00:00\n"
+"POT-Creation-Date: 2020-11-05 12:15:09+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -485,11 +485,11 @@ msgstr ""
 msgid "%1$dx of %2$s %3$s"
 msgstr ""
 
-#: woocommerce-pagarme.php:127
+#: woocommerce-pagarme.php:132
 msgid "Bank Slip Settings"
 msgstr ""
 
-#: woocommerce-pagarme.php:129
+#: woocommerce-pagarme.php:134
 msgid "Credit Card Settings"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: pagarme, claudiosanches, murilohns
 Tags: woocommerce, pagarme, payment
 Requires at least: 4.0
-Tested up to: 5.2
-Stable tag: 2.2.0
+Tested up to: 5.5
+Stable tag: 2.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -117,6 +117,9 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 
 == Changelog ==
 
+= 2.3.0 - 2020-11-05 =
+
+* Torna o campo bairro obrigatório
 
 = 2.2.0 - 2020-09-10 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pagar.me for WooCommerce ===
-Contributors: pagarme, claudiosanches
+Contributors: pagarme, claudiosanches, murilohns
 Tags: woocommerce, pagarme, payment
 Requires at least: 4.0
 Tested up to: 5.2

--- a/tests/e2e/wc-checkout-page.spec.js
+++ b/tests/e2e/wc-checkout-page.spec.js
@@ -1,0 +1,15 @@
+context('Woocommerce Checkout Page', () => {
+  describe('when go to the woocommerce checkout page', () => {
+    before(() => {
+      cy.addProductToCart()
+      cy.goToCheckoutPage()
+    })
+  
+    describe('billing_neighborhood field', () => {
+      it('should be required', () => {
+        cy.get('#billing_neighborhood_field')
+          .should('have.class', 'validate-required')
+      })
+    })
+  })
+})

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 			// Load plugin text domain.
 			add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 
-			// Checks with WooCommerce is installed.
+			// Checks if WooCommerce is installed.
 			if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				$this->upgrade();
 				$this->includes();
@@ -54,6 +54,11 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 				add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
 			} else {
 				add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
+			}
+
+			// Custom settings for the "Brazilian Market on WooCommerce" plugin billing fields.
+			if ( class_exists( 'Extra_Checkout_Fields_For_Brazil' ) ) {
+				add_action( 'wcbcf_billing_fields', array( $this, 'wcbcf_billing_fields_custom_settings' ) );
 			}
 		}
 
@@ -177,6 +182,19 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 					delete_option( 'woocommerce_pagarme_settings' );
 				}
 			}
+		}
+
+		/**
+		 * Custom settings for the "Brazilian Market on WooCommerce" plugin billing fields.
+		 *
+		 * @param  array $wcbcf_billing_fields "Brazilian Market on WooCommerce" plugin billing fields.
+		 *
+		 * @return array
+		 */
+		public function wcbcf_billing_fields_custom_settings( $wcbcf_billing_fields ) {
+			$wcbcf_billing_fields['billing_neighborhood']['required'] = true;
+
+			return $wcbcf_billing_fields;
 		}
 	}
 

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -5,7 +5,7 @@
  * Description: Gateway de pagamento Pagar.me para WooCommerce.
  * Author: Pagar.me, Claudio Sanches
  * Author URI: https://pagar.me/
- * Version: 2.1.0
+ * Version: 2.3.0
  * License: GPLv2 or later
  * Text Domain: woocommerce-pagarme
  * Domain Path: /languages/
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '2.2.0';
+		const VERSION = '2.3.0';
 
 		/**
 		 * Instance of this class.


### PR DESCRIPTION
Esse PR tem o intuito de **tornar o campo bairro obrigatório** (campo _billing_neighborhood_ do plugin _Brazilian Market on WooCommerce_), já que esse é um campo obrigatório da API da Pagar.me.