### PR TITLE
Corrige o build dos testes e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ wp-install:
 	&& docker-compose exec woopagarme chown www-data:www-data -R /var/www/html/wp-content/uploads/wc-logs
 
 wp-setup:
-	docker-compose exec woopagarme wp plugin install woocommerce \
+	docker-compose exec woopagarme wp plugin install woocommerce --version=3.7.0 \
 	woocommerce-extra-checkout-fields-for-brazil --activate --allow-root \
 	&& docker-compose exec woopagarme wp plugin activate woocommerce-pagarme --allow-root \
 	&& docker-compose exec woopagarme wp plugin install wordpress-importer --activate --allow-root \

--- a/tests/e2e/boleto.spec.js
+++ b/tests/e2e/boleto.spec.js
@@ -17,7 +17,8 @@ context('Boleto', () => {
 
     it('should countains boleto url', () => {
       cy.contains('Pagar boleto bancário')
-        .and('have.attr', 'href', 'https://pagar.me' )
+		.and('have.attr', 'href' )
+		.should('match', new RegExp(/https:\/\/api.pagar.me\/1\/boletos\/test_/g))
     })
   })
 })


### PR DESCRIPTION
### Contexto

Investigando o motivo de falha dos testes e2e, descobri que está relacionado com a versão do Woocommerce.

O último build que passou estava utilizando Woocommerce 3.7.0, e os builds seguintes começaram a usar Woocommerce 4.0 ou superior.

Aparentemente o Woocommerce 4.0+ não é compatível com PHP5.6, que é utilizado na imagem Docker para fazer o build, então ocorria uma falha na ativação do plugin.

### Correção

Para corrigir o build, vamos travar a versão do Woocommerce instalado em 3.7.0, que é a versão compatível com PHP5.6

No futuro podemos pensar em mudar a versão da imagem para PHP7, mas não provavelmente terá algumas quebrar de interface com o módulo que precisarão ser corrigidas.