### PR TITLE
Fix/revert brazilian market required

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** woocommerce, pagarme, payment  
 **Requires at least:** 4.0  
 **Tested up to:** 5.6  
-**Stable tag:** 2.4.0  
+**Stable tag:** 2.4.1  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -124,6 +124,10 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 
 
 ## Changelog ##
+
+### 2.4.1 - 2020-12-17 ###
+
+* Fix: Reverte a alteração que tornava o plugin Brazilian Market on WooCommerce obrigatório
 
 ### 2.4.0 - 2020-12-16 ###
 

--- a/languages/woocommerce-pagarme.pot
+++ b/languages/woocommerce-pagarme.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pagar.me for WooCommerce 2.4.0\n"
+"Project-Id-Version: Pagar.me for WooCommerce 2.4.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-pagarme\n"
-"POT-Creation-Date: 2020-12-16 15:51:50+00:00\n"
+"POT-Creation-Date: 2020-12-17 15:09:52+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -499,11 +499,11 @@ msgstr ""
 msgid "%1$dx of %2$s %3$s"
 msgstr ""
 
-#: woocommerce-pagarme.php:139
+#: woocommerce-pagarme.php:132
 msgid "Bank Slip Settings"
 msgstr ""
 
-#: woocommerce-pagarme.php:141
+#: woocommerce-pagarme.php:134
 msgid "Credit Card Settings"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pagarme, claudiosanches, murilohns
 Tags: woocommerce, pagarme, payment
 Requires at least: 4.0
 Tested up to: 5.6
-Stable tag: 2.4.0
+Stable tag: 2.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -117,7 +117,11 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 
 == Changelog ==
 
-### 2.4.0 - 2020-12-16 ###
+= 2.4.1 - 2020-12-17 =
+
+* Fix: Reverte a alteração que tornava o plugin Brazilian Market on WooCommerce obrigatório
+
+= 2.4.0 - 2020-12-16 =
 
 * Torna o plugin Brazilian Market on WooCommerce obrigatório
 

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -5,7 +5,7 @@
  * Description: Gateway de pagamento Pagar.me para WooCommerce.
  * Author: Pagar.me, Claudio Sanches
  * Author URI: https://pagar.me/
- * Version: 2.4.0
+ * Version: 2.4.1
  * License: GPLv2 or later
  * Text Domain: woocommerce-pagarme
  * Domain Path: /languages/
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '2.4.0';
+		const VERSION = '2.4.1';
 
 		/**
 		 * Instance of this class.

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -45,27 +45,20 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 			// Load plugin text domain.
 			add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 
-			// Checks if WooCommerce and Brazilian Market plugins are installed.
-			$woocommerce_is_installed = class_exists( 'WC_Payment_Gateway' );
-			$brazilian_market_is_installed = class_exists( 'Extra_Checkout_Fields_For_Brazil' );
-
-			if ( $woocommerce_is_installed && $brazilian_market_is_installed ) {
+			// Checks if WooCommerce is installed.
+			if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				$this->upgrade();
 				$this->includes();
 
 				add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
 				add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
-
-				// Custom settings for Brazilian Market plugin billing fields.
-				add_action( 'wcbcf_billing_fields', array( $this, 'wcbcf_billing_fields_custom_settings' ) );
 			} else {
-				if ( ! $woocommerce_is_installed ) {
-					add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
-				}
+				add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
+			}
 
-				if ( ! $brazilian_market_is_installed ) {
-					add_action( 'admin_notices', array( $this, 'brazilian_market_missing_notice' ) );
-				}
+			// Custom settings for the "Brazilian Market on WooCommerce" plugin billing fields.
+			if ( class_exists( 'Extra_Checkout_Fields_For_Brazil' ) ) {
+				add_action( 'wcbcf_billing_fields', array( $this, 'wcbcf_billing_fields_custom_settings' ) );
 			}
 		}
 
@@ -148,13 +141,6 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 		 */
 		public function woocommerce_missing_notice() {
 			include dirname( __FILE__ ) . '/includes/admin/views/html-notice-missing-woocommerce.php';
-		}
-
-		/**
-		 * Brazilian Market fallback notice.
-		 */
-		public function brazilian_market_missing_notice() {
-			include dirname( __FILE__ ) . '/includes/admin/views/html-notice-missing-brazilian-market.php';
 		}
 
 		/**


### PR DESCRIPTION
Reverte o PR https://github.com/claudiosanches/woocommerce-pagarme/pull/141, pois clientes que utilizavam outro plugin (ou outra forma de enviar esses campos) relataram problemas.